### PR TITLE
Broadcast 복사 제거

### DIFF
--- a/Chat_Client/Client.cpp
+++ b/Chat_Client/Client.cpp
@@ -59,7 +59,7 @@ DWORD WINAPI WriteThreadMain(shared_ptr<ServerSession> session)
 			break;
 		}
 
-		shared_ptr<Packet> p =make_shared<Packet>(ePacketType::WRITE_PACKET,session->GetSendBuffer());
+		shared_ptr<Packet> p =make_shared<Packet>(ePacketType::WRITE_PACKET);
 		p->startPacket(Protocol::C2S_CHAT_REQ);
 		p->push(chat);
 		p->endPacket(Protocol::C2S_CHAT_REQ);

--- a/Chat_Client/Client.cpp
+++ b/Chat_Client/Client.cpp
@@ -59,12 +59,12 @@ DWORD WINAPI WriteThreadMain(shared_ptr<ServerSession> session)
 			break;
 		}
 
-		Packet* p = new Packet(ePacketType::WRITE_PACKET,session->GetSendBuffer());
+		shared_ptr<Packet> p =make_shared<Packet>(ePacketType::WRITE_PACKET,session->GetSendBuffer());
 		p->startPacket(Protocol::C2S_CHAT_REQ);
 		p->push(chat);
 		p->endPacket(Protocol::C2S_CHAT_REQ);
 
-		session->Send(p);
+		session->Send(move(p));
 	}
 
 	return 0;

--- a/Chat_Client/ServerSession.cpp
+++ b/Chat_Client/ServerSession.cpp
@@ -10,7 +10,7 @@ ServerSession::ServerSession(HANDLE iocp)
 
 void ServerSession::DoDisconnect()
 {
-	shared_ptr<Packet> p =make_shared<Packet>(ePacketType::WRITE_PACKET, GetSendBuffer());
+	shared_ptr<Packet> p =make_shared<Packet>(ePacketType::WRITE_PACKET);
 
 	p->startPacket(Protocol::C2S_EXIT_ROOM);
 	p->endPacket(Protocol::C2S_EXIT_ROOM);
@@ -20,7 +20,7 @@ void ServerSession::DoDisconnect()
 
 void ServerSession::OnConnected()
 {
-	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET, GetSendBuffer());
+	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET);
 	p->startPacket(Protocol::C2S_ENTER_ROOM);
 	p->push(nickName);
 	p->endPacket(Protocol::C2S_ENTER_ROOM);

--- a/Chat_Client/ServerSession.cpp
+++ b/Chat_Client/ServerSession.cpp
@@ -10,7 +10,7 @@ ServerSession::ServerSession(HANDLE iocp)
 
 void ServerSession::DoDisconnect()
 {
-	shared_ptr<Packet> p = new shared_ptr<Packet>(ePacketType::WRITE_PACKET, GetSendBuffer());
+	shared_ptr<Packet> p =make_shared<Packet>(ePacketType::WRITE_PACKET, GetSendBuffer());
 
 	p->startPacket(Protocol::C2S_EXIT_ROOM);
 	p->endPacket(Protocol::C2S_EXIT_ROOM);

--- a/Chat_Client/ServerSession.cpp
+++ b/Chat_Client/ServerSession.cpp
@@ -10,22 +10,22 @@ ServerSession::ServerSession(HANDLE iocp)
 
 void ServerSession::DoDisconnect()
 {
-	Packet p(ePacketType::WRITE_PACKET, GetSendBuffer());
+	shared_ptr<Packet> p = new shared_ptr<Packet>(ePacketType::WRITE_PACKET, GetSendBuffer());
 
-	p.startPacket(Protocol::C2S_EXIT_ROOM);
-	p.endPacket(Protocol::C2S_EXIT_ROOM);
+	p->startPacket(Protocol::C2S_EXIT_ROOM);
+	p->endPacket(Protocol::C2S_EXIT_ROOM);
 
-	Send(&p);
+	Send(move(p));
 }
 
 void ServerSession::OnConnected()
 {
-	Packet* p = new Packet(ePacketType::WRITE_PACKET, GetSendBuffer());
+	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET, GetSendBuffer());
 	p->startPacket(Protocol::C2S_ENTER_ROOM);
 	p->push(nickName);
 	p->endPacket(Protocol::C2S_ENTER_ROOM);
 
-	Send(p);
+	Send(move(p));
 }
 
 void ServerSession::OnSend(int sendSize)

--- a/Chat_Server/PacketHandler.cpp
+++ b/Chat_Server/PacketHandler.cpp
@@ -19,7 +19,7 @@ void PacketHandler::C2S_CHAT_REQ_Handler(shared_ptr<Session> session, Packet* pa
 	packet->pop(chat);
 	chat = cliSession->_userInfo.nickName + ": " + chat;
 
-	Packet* p = new Packet(ePacketType::WRITE_PACKET,cliSession->GetSendBuffer());
+	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET,cliSession->GetSendBuffer());
 	p->startPacket(Protocol::S2C_CHAT_RES);
 	p->push(chat);
 	p->endPacket(Protocol::S2C_CHAT_RES);

--- a/Chat_Server/PacketHandler.cpp
+++ b/Chat_Server/PacketHandler.cpp
@@ -19,7 +19,7 @@ void PacketHandler::C2S_CHAT_REQ_Handler(shared_ptr<Session> session, Packet* pa
 	packet->pop(chat);
 	chat = cliSession->_userInfo.nickName + ": " + chat;
 
-	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET,cliSession->GetSendBuffer());
+	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET);
 	p->startPacket(Protocol::S2C_CHAT_RES);
 	p->push(chat);
 	p->endPacket(Protocol::S2C_CHAT_RES);

--- a/Chat_Server/Room.cpp
+++ b/Chat_Server/Room.cpp
@@ -2,14 +2,13 @@
 #include "Room.h"
 
 Room* g_Room = nullptr;
+using namespace std;
 
-void Room::Broadcast(Packet* packet)
+void Room::Broadcast(shared_ptr<Packet> packet)
 {
 	for (auto& r : _sessions)
 		r->SendByCopy(packet->GetBuffer());
 
-	packet->GetBuffer()->CompleteRead(packet->GetSize());
-	delete packet;
 }
 
 void Room::Join(shared_ptr<ClientSession> session)

--- a/Chat_Server/Room.cpp
+++ b/Chat_Server/Room.cpp
@@ -18,7 +18,7 @@ void Room::Join(shared_ptr<ClientSession> session)
 	
 	session->_userInfo.userId = ++_id;
 
-	Packet* p = new Packet(ePacketType::WRITE_PACKET,session->GetSendBuffer());
+	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET,session->GetSendBuffer());
 	p->startPacket(Protocol::S2C_ENTER_ROOM_NOTIFY);
 	string contents;
 	contents = "[ÀÔÀå] " + session->_userInfo.nickName + "´ÔÀÌ ÀÔÀåÇß½À´Ï´Ù.";
@@ -32,7 +32,7 @@ void Room::Exit(shared_ptr<ClientSession> session)
 {
 	_sessions.erase(session);
 
-	Packet* p = new Packet(ePacketType::WRITE_PACKET, session->GetSendBuffer());
+	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET, session->GetSendBuffer());
 
 	string contents;
 	contents = "[ÅðÀå] " + session->_userInfo.nickName + "´ÔÀÌ ÅðÀåÇß½À´Ï´Ù.";

--- a/Chat_Server/Room.cpp
+++ b/Chat_Server/Room.cpp
@@ -7,7 +7,7 @@ using namespace std;
 void Room::Broadcast(shared_ptr<Packet> packet)
 {
 	for (auto& r : _sessions)
-		r->SendByCopy(packet->GetBuffer());
+		r->Send(packet);
 
 }
 
@@ -17,7 +17,7 @@ void Room::Join(shared_ptr<ClientSession> session)
 	
 	session->_userInfo.userId = ++_id;
 
-	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET,session->GetSendBuffer());
+	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET);
 	p->startPacket(Protocol::S2C_ENTER_ROOM_NOTIFY);
 	string contents;
 	contents = "[ÀÔÀå] " + session->_userInfo.nickName + "´ÔÀÌ ÀÔÀåÇß½À´Ï´Ù.";
@@ -31,7 +31,7 @@ void Room::Exit(shared_ptr<ClientSession> session)
 {
 	_sessions.erase(session);
 
-	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET, session->GetSendBuffer());
+	shared_ptr<Packet> p = make_shared<Packet>(ePacketType::WRITE_PACKET);
 
 	string contents;
 	contents = "[ÅðÀå] " + session->_userInfo.nickName + "´ÔÀÌ ÅðÀåÇß½À´Ï´Ù.";

--- a/Chat_Server/Room.h
+++ b/Chat_Server/Room.h
@@ -6,7 +6,7 @@ extern Room* g_Room;
 class Room
 {
 public:
-	void Broadcast(Packet* packet);
+	void Broadcast(shared_ptr<Packet> p);
 
 	void Join(shared_ptr<ClientSession> session);
 

--- a/Network/Buffer.cpp
+++ b/Network/Buffer.cpp
@@ -25,8 +25,7 @@ void Buffer::CompleteRead(int readByte)
 
 	_readPos += readByte;
 
-	if (_writePos == _readPos)
-		_writePos = _readPos = 0;
+	Clear();
 		
 }
 
@@ -39,6 +38,12 @@ void Buffer::CompleteWrite(int writeByte)
 	}
 
 	_writePos += writeByte;
+}
+
+void Buffer::Clear()
+{
+	if (_writePos == _readPos)
+		_writePos = _readPos = 0;
 }
 
 char* Buffer::Reserve(int size)

--- a/Network/Buffer.h
+++ b/Network/Buffer.h
@@ -26,6 +26,7 @@ public:
 	void CompleteRead(int readByte);
 	void CompleteWrite(int writeByte);
 
+	void Clear();
 	char* Reserve(int size);
 private:
 	int _readPos;

--- a/Network/BufferManager.cpp
+++ b/Network/BufferManager.cpp
@@ -31,5 +31,6 @@ Buffer* BufferManager::AssignBuffer()
 
 void BufferManager::ReturnBuffer(Buffer* buffer)
 {
+	buffer->Clear();
 	_buffers.push(buffer);
 }

--- a/Network/Packet.cpp
+++ b/Network/Packet.cpp
@@ -15,13 +15,22 @@ Packet::Packet(unsigned char type, char* buffer)
 	_idx += sizeof(PacketHeader);
 }
 
-Packet::Packet(unsigned char type, Buffer* buffer)
+Packet::Packet(unsigned char type)
 {
 	if (type != ePacketType::WRITE_PACKET)
-		/*Å©·¡½Ã */ return;
+		return;
 
 	packetType = type;
-	_writeBuffer = buffer;
+	_writeBuffer = GBufferManager->AssignBuffer();
+}
+
+Packet::~Packet()
+{
+	if(packetType == ePacketType::WRITE_PACKET)
+	{ 
+		_writeBuffer->CompleteRead(_idx);
+		GBufferManager->ReturnBuffer(_writeBuffer);
+	}
 }
 
 void Packet::startPacket(int packetId)
@@ -31,6 +40,7 @@ void Packet::startPacket(int packetId)
 
 	_idx += sizeof(PacketHeader);
 	_header.packetId = packetId;
+
 }
 
 void Packet::endPacket(int packetId)

--- a/Network/Packet.h
+++ b/Network/Packet.h
@@ -10,7 +10,7 @@ struct PacketHeader
 	unsigned short size;
 	unsigned short packetId;
 };
-#	pragma pack(pop)W
+#	pragma pack(pop)
 
 enum ePacketType : unsigned char
 {
@@ -26,8 +26,8 @@ class Packet
 {
 public:
 	Packet(unsigned char type, char* buffer);
-	Packet(unsigned char type, Buffer* buffer);
-	~Packet() = default;
+	Packet(unsigned char type);
+	~Packet();
 public:
 	void startPacket(int packetId);
 	void endPacket(int packetId);

--- a/Network/Session.h
+++ b/Network/Session.h
@@ -21,7 +21,6 @@ public:
 
 	void Connect(std::string ip, int port);
 	void Send(shared_ptr<Packet> p);
-	void SendByCopy(Buffer* packetBuffer);
 	virtual void DoDisconnect();
 private:
 	int OnRecv();
@@ -37,8 +36,6 @@ public:
 
 	char _ip[INET_ADDRSTRLEN];
 	int _port = 0;
-public:
-	Buffer* GetSendBuffer();
 private:
 	
 	HANDLE _iocpHandle;
@@ -54,7 +51,6 @@ private:
 	vector<shared_ptr<Packet>> _sendCompletePacket;
 	mutex _sendLock;
 
-	Buffer* _sendBuffer;
 	Buffer _recvBuffer;
 };
 

--- a/Network/Session.h
+++ b/Network/Session.h
@@ -20,7 +20,7 @@ public:
 	void CompletedDisconnect();
 
 	void Connect(std::string ip, int port);
-	void Send(Packet* p);
+	void Send(shared_ptr<Packet> p);
 	void SendByCopy(Buffer* packetBuffer);
 	virtual void DoDisconnect();
 private:
@@ -50,8 +50,8 @@ private:
 
 	SendEvent _sendEvent;
 	atomic<bool> _isSendRegister;
-	concurrent_queue<Packet*> _sendRegisteredPacket;
-	vector<Packet*> _sendCompletePacket;
+	concurrent_queue<shared_ptr<Packet>> _sendRegisteredPacket;
+	vector<shared_ptr<Packet>> _sendCompletePacket;
 	mutex _sendLock;
 
 	Buffer* _sendBuffer;


### PR DESCRIPTION
## 변경점

1. writeBuffer를 packet이 관리
   SendBuffer를 매니저로 풀링하고 있으니, Session이 아닌 Packet에서 관리하도록 변경

2. packet을 shared_ptr로 관리
    → SendComplete때 버퍼를 반납하는 것이 아닌 Pakcet의 소멸자에서 Buffer를 반납하자.
    → Send를 하는 Pakcet을 컨테이너에 담아둬 reference Count를 1 올려준다. → 소멸 X 유지
    → Send 완료 시 컨테이너 clear
    → 모두 broadcast 하면 referenceCount가 0이 되어 소멸자 call
