### PR TITLE
로직 스레드 분리 작업

### DIFF
--- a/Chat_Client/Client.cpp
+++ b/Chat_Client/Client.cpp
@@ -7,7 +7,7 @@ int main() {
 	ClientService* service = new ClientService(L"127.0.0.1",7777,[]()
 	{
 		return make_shared<ServerSession>();
-	},1);
+	},2);
 	service->Open();
 	
 	GThreadManager->JoinAll();

--- a/Chat_Client/PacketHandler.cpp
+++ b/Chat_Client/PacketHandler.cpp
@@ -1,7 +1,7 @@
 ﻿#include "stdafx.h"
 #include "PacketHandler.h"
 
-void PacketHandler::LATENCY_CHECK_Handler(shared_ptr<Session> session, Packet* packet)
+void PacketHandler::LATENCY_CHECK_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet)
 {
 	shared_ptr<ServerSession> serverSession = static_pointer_cast<ServerSession>(session);
 
@@ -10,21 +10,21 @@ void PacketHandler::LATENCY_CHECK_Handler(shared_ptr<Session> session, Packet* p
 #endif
 }
 
-void PacketHandler::S2C_ENTER_ROOM_NOTIFY_Handler(shared_ptr<Session> session, Packet* packet)
+void PacketHandler::S2C_ENTER_ROOM_NOTIFY_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet)
 {
 	string str;
 	packet->pop(str);
 	cout << str << endl;
 }
 
-void PacketHandler::S2C_CHAT_RES_Handler(shared_ptr<Session> session, Packet* packet)
+void PacketHandler::S2C_CHAT_RES_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet)
 {
 	string chat;
 	packet->pop(chat);
 	cout << chat << endl;
   }
 
-void PacketHandler::S2C_EXIT_ROOM_NOTIFY_Handler(shared_ptr<Session> session, Packet* packet)
+void PacketHandler::S2C_EXIT_ROOM_NOTIFY_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet)
 {
 	string str;
 	packet->pop(str);

--- a/Chat_Client/PacketHandler.h
+++ b/Chat_Client/PacketHandler.h
@@ -2,9 +2,9 @@
 class PacketHandler
 {
 public:
-	static void LATENCY_CHECK_Handler(shared_ptr<Session> session, Packet* packet);
-	static void S2C_ENTER_ROOM_NOTIFY_Handler(shared_ptr<Session> session, Packet* packet);
-	static void S2C_CHAT_RES_Handler(shared_ptr<Session> session, Packet* packet);
-	static void S2C_EXIT_ROOM_NOTIFY_Handler(shared_ptr<Session> session, Packet* packet);
+	static void LATENCY_CHECK_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet);
+	static void S2C_ENTER_ROOM_NOTIFY_Handler(shared_ptr<Session> session, std::shared_ptr<Packet>  packet);
+	static void S2C_CHAT_RES_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet);
+	static void S2C_EXIT_ROOM_NOTIFY_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet);
 };
 

--- a/Chat_Client/ServerSession.cpp
+++ b/Chat_Client/ServerSession.cpp
@@ -62,7 +62,7 @@ void ServerSession::OnDisconnect()
 
 }
 
-void ServerSession::OnAssemblePacket(Packet* packet)
+void ServerSession::OnAssemblePacket(std::shared_ptr<Packet> packet)
 {
 	clock_t curTick = clock();
 

--- a/Chat_Client/ServerSession.h
+++ b/Chat_Client/ServerSession.h
@@ -23,7 +23,7 @@ private:
 	void OnSend(int sendSize) override;
 	void OnDisconnect() override;
 
-	void OnAssemblePacket(Packet* packet) override;
+	void OnAssemblePacket(std::shared_ptr<Packet> packet) override;
 	
 public:
 	DWORD WINAPI ChattingLogic();

--- a/Chat_Server/ClientSession.cpp
+++ b/Chat_Server/ClientSession.cpp
@@ -14,7 +14,7 @@ void ClientSession::OnDisconnect()
 {
 }
 
-void ClientSession::OnAssemblePacket(Packet* packet)
+void ClientSession::OnAssemblePacket(std::shared_ptr<Packet> packet)
 {
 	shared_ptr<Session> session = static_pointer_cast<Session>(shared_from_this());
 

--- a/Chat_Server/ClientSession.h
+++ b/Chat_Server/ClientSession.h
@@ -19,7 +19,7 @@ private:
 	void OnSend(int sendSize) override;
 	void OnDisconnect() override;
 
-	virtual void OnAssemblePacket(Packet* packet) override;
+	virtual void OnAssemblePacket(std::shared_ptr<Packet> packet) override;
 
 public:
 	UserInfo _userInfo;

--- a/Chat_Server/PacketHandler.cpp
+++ b/Chat_Server/PacketHandler.cpp
@@ -1,7 +1,7 @@
 ﻿#include "stdafx.h"
 #include "PacketHandler.h"
 
-void PacketHandler::LATENCY_CHECK_Handler(shared_ptr<Session> session, Packet* packet)
+void PacketHandler::LATENCY_CHECK_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet)
 {
 	shared_ptr<ClientSession> cliSession = static_pointer_cast<ClientSession>(session);
 	
@@ -15,7 +15,7 @@ void PacketHandler::LATENCY_CHECK_Handler(shared_ptr<Session> session, Packet* p
 	cliSession->Send(p);
 }
 
-void PacketHandler::C2S_ENTER_ROOM_Handler(shared_ptr<Session> session, Packet* packet)
+void PacketHandler::C2S_ENTER_ROOM_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet)
 {
 	shared_ptr<ClientSession> cliSession = static_pointer_cast<ClientSession>(session);
 
@@ -24,7 +24,7 @@ void PacketHandler::C2S_ENTER_ROOM_Handler(shared_ptr<Session> session, Packet* 
 	g_Room->Join(cliSession, packet);
 }
 
-void PacketHandler::C2S_CHAT_REQ_Handler(shared_ptr<Session> session, Packet* packet)
+void PacketHandler::C2S_CHAT_REQ_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet)
 {
 	// 다른 사람에게 채팅 정보 보내기
 	shared_ptr<ClientSession> cliSession = static_pointer_cast	<ClientSession>(session);
@@ -44,7 +44,7 @@ void PacketHandler::C2S_CHAT_REQ_Handler(shared_ptr<Session> session, Packet* pa
 	g_Room->Broadcast(p);
 }
 
-void PacketHandler::C2S_EXIT_ROOM_Handler(shared_ptr<Session> session, Packet* packet)
+void PacketHandler::C2S_EXIT_ROOM_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet)
 {
 	shared_ptr<ClientSession> cliSession = static_pointer_cast<ClientSession>(session);
 	g_Room->Exit(cliSession, packet);

--- a/Chat_Server/PacketHandler.h
+++ b/Chat_Server/PacketHandler.h
@@ -2,9 +2,9 @@
 class PacketHandler
 {
 public:
-	static void LATENCY_CHECK_Handler(shared_ptr<Session> session, Packet* packet);
-	static void C2S_ENTER_ROOM_Handler(shared_ptr<Session> session, Packet* packet);
-	static void C2S_CHAT_REQ_Handler(shared_ptr<Session> session, Packet* packet);
-	static void C2S_EXIT_ROOM_Handler(shared_ptr<Session> session, Packet* packet);
+	static void LATENCY_CHECK_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet);
+	static void C2S_ENTER_ROOM_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet);
+	static void C2S_CHAT_REQ_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet);
+	static void C2S_EXIT_ROOM_Handler(shared_ptr<Session> session, std::shared_ptr<Packet> packet);
 };
 

--- a/Chat_Server/Room.cpp
+++ b/Chat_Server/Room.cpp
@@ -11,7 +11,7 @@ void Room::Broadcast(shared_ptr<Packet> packet)
 
 }
 
-void Room::Join(shared_ptr<ClientSession> session, Packet* enterReqPacket)
+void Room::Join(shared_ptr<ClientSession> session, shared_ptr<Packet> enterReqPacket)
 {
 	_sessions.insert(session);
 	
@@ -31,7 +31,7 @@ void Room::Join(shared_ptr<ClientSession> session, Packet* enterReqPacket)
 	Broadcast(p);
 }
 
-void Room::Exit(shared_ptr<ClientSession> session, Packet* exitReqPacket)
+void Room::Exit(shared_ptr<ClientSession> session, shared_ptr<Packet> exitReqPacket)
 {
 	_sessions.erase(session);
 

--- a/Chat_Server/Room.h
+++ b/Chat_Server/Room.h
@@ -6,11 +6,11 @@ extern Room* g_Room;
 class Room
 {
 public:
-	void Broadcast(shared_ptr<Packet> p);
+	void Broadcast(std::shared_ptr<Packet> p);
 
-	void Join(shared_ptr<ClientSession> session, Packet* enterReqPacket);
+	void Join(shared_ptr<ClientSession> session, std::shared_ptr<Packet> enterReqPacket);
 
-	void Exit(shared_ptr<ClientSession> session, Packet* exitReqPacket);
+	void Exit(shared_ptr<ClientSession> session, std::shared_ptr<Packet> exitReqPacket);
 private:
 	set<shared_ptr<ClientSession>> _sessions;
 	int _id;

--- a/Network/LogicWorker.cpp
+++ b/Network/LogicWorker.cpp
@@ -1,0 +1,42 @@
+#include "stdafx.h"
+#include "LogicWorker.h"
+
+LogicWorker::LogicWorker()
+{
+	_jobAddEvent = ::CreateEvent(NULL, FALSE, FALSE, NULL);
+}
+
+LogicWorker::~LogicWorker()
+{
+	CloseHandle(_jobAddEvent);
+}
+
+void LogicWorker::Init()
+{
+	_assembledPackets.clear();
+}
+
+void LogicWorker::Work()
+{
+	while (true)
+	{
+		std::shared_ptr<Packet> packet = nullptr;
+
+		_assembledPackets.try_pop(packet);
+		
+		if (packet == nullptr)
+			continue;
+		
+
+		Session* session = packet->GetOwner();
+		session->OnAssemblePacket(packet);
+		
+		::WaitForSingleObject(_jobAddEvent, 100);
+	}
+}
+
+void LogicWorker::PushJob(shared_ptr<Packet> p)
+{
+	_assembledPackets.push(p);
+	SetEvent(_jobAddEvent);
+}

--- a/Network/LogicWorker.h
+++ b/Network/LogicWorker.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "Worker.h"
+#include <concurrent_queue.h>
+
+class LogicWorker : public Worker
+{
+public:
+    LogicWorker();
+    ~LogicWorker() override;
+    
+public:
+    void Init() override;
+    void Work() override;
+
+	void PushJob(std::shared_ptr<Packet> p);
+private:
+    HANDLE _jobAddEvent;
+    Concurrency::concurrent_queue<std::shared_ptr<class Packet>> _assembledPackets;
+
+};
+

--- a/Network/Network.vcxproj
+++ b/Network/Network.vcxproj
@@ -160,6 +160,7 @@
     <ClInclude Include="ioEvent.h" />
     <ClInclude Include="Listener.h" />
     <ClInclude Include="Logger.h" />
+    <ClInclude Include="LogicWorker.h" />
     <ClInclude Include="Macro.h" />
     <ClInclude Include="NetworkIncludes.h" />
     <ClInclude Include="NetworkUtil.h" />
@@ -180,6 +181,7 @@
     <ClCompile Include="CoreGlobal.cpp" />
     <ClCompile Include="IocpWorker.cpp" />
     <ClCompile Include="Listener.cpp" />
+    <ClCompile Include="LogicWorker.cpp" />
     <ClCompile Include="NetworkIncludes.cpp" />
     <ClCompile Include="NetworkUtil.cpp" />
     <ClCompile Include="Packet.cpp" />

--- a/Network/Network.vcxproj.filters
+++ b/Network/Network.vcxproj.filters
@@ -56,12 +56,20 @@
     </ClInclude>
     <ClInclude Include="Macro.h" />
     <ClInclude Include="Config.h" />
-    <ClInclude Include="IocpWorker.h" />
     <ClInclude Include="Logger.h" />
     <ClInclude Include="ServerService.h" />
     <ClInclude Include="Service.h" />
     <ClInclude Include="Singleton.h" />
-    <ClInclude Include="Worker.h" />
+    <ClInclude Include="ClientService.h" />
+    <ClInclude Include="IocpWorker.h">
+      <Filter>Thread</Filter>
+    </ClInclude>
+    <ClInclude Include="Worker.h">
+      <Filter>Thread</Filter>
+    </ClInclude>
+    <ClInclude Include="LogicWorker.h">
+      <Filter>Thread</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Buffer.cpp">
@@ -94,9 +102,17 @@
     <ClCompile Include="Packet.cpp">
       <Filter>Network</Filter>
     </ClCompile>
-    <ClCompile Include="IocpWorker.cpp" />
     <ClCompile Include="ServerService.cpp" />
     <ClCompile Include="Service.cpp" />
-    <ClCompile Include="Worker.cpp" />
+    <ClCompile Include="ClientService.cpp" />
+    <ClCompile Include="IocpWorker.cpp">
+      <Filter>Thread</Filter>
+    </ClCompile>
+    <ClCompile Include="Worker.cpp">
+      <Filter>Thread</Filter>
+    </ClCompile>
+    <ClCompile Include="LogicWorker.cpp">
+      <Filter>Thread</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/Network/Packet.h
+++ b/Network/Packet.h
@@ -1,5 +1,6 @@
 #pragma once
 
+class Session;
 
 #	pragma pack(push)
 #	pragma pack(1)
@@ -53,12 +54,16 @@ public:
 	}
 #endif
 	
+public: 
+	Session* GetOwner() { return _owner; }
+	void SetOwner(Session* session) { _owner = session; }
 private:
 	PacketHeader _header;
+
+	Session* _owner;
 private:
 	/* Write용 */
 	Buffer* _writeBuffer;
-	// 전송할 데이터 끝
 
 private:
 	/* Read용 */

--- a/Network/Service.cpp
+++ b/Network/Service.cpp
@@ -14,6 +14,8 @@ Service::Service(const WCHAR* ip, int port, SessionFactory factory)
     
     _iocpWorker.Init();
     _iocpWorker.SetHandle(_iocpHandle);
+
+    _logicWorker.Init();
 }
 
 Service::~Service()
@@ -31,6 +33,7 @@ void Service::Open()
     
     _isOpen = true;
     _iocpWorker.StartWork(1);
+    _logicWorker.StartWork(1);
 }
 
 void Service::Close()

--- a/Network/Service.h
+++ b/Network/Service.h
@@ -4,6 +4,7 @@
 #include <Esent.h>
 #include <concrt.h>
 #include "IocpWorker.h"
+#include "LogicWorker.h"
 #include <mutex>
 #include <set>
 
@@ -26,6 +27,7 @@ public:
     void AddSession(std::shared_ptr<Session> session);
     void DeleteSession(std::shared_ptr<Session>&& session);
 
+    void PushJob(std::shared_ptr<Packet> p) { _logicWorker.PushJob(move(p)); }
 public:
     const WCHAR* GetIp() { return _ip; }
     int GetPort() { return _port; }
@@ -40,6 +42,7 @@ private:
 	int _port = 0;
     
     IocpWorker _iocpWorker;
+    LogicWorker _logicWorker;
 
     std::mutex _sessionContainerLock;
     std::set<std::shared_ptr<Session>> _sessions;

--- a/Network/Session.cpp
+++ b/Network/Session.cpp
@@ -266,8 +266,9 @@ int Session::OnRecv()
 		if (recvSize - processLen < header.size)
 			break;
 
-		Packet p(ePacketType::READ_PACKET, buffer + processLen);
-		OnAssemblePacket(&p);
+		shared_ptr<Packet> p = make_shared<Packet>(ePacketType::READ_PACKET, buffer + processLen);
+		p->SetOwner(this);
+		_service->PushJob(move(p));
 
 		processLen += header.size;
 	}

--- a/Network/Session.h
+++ b/Network/Session.h
@@ -33,7 +33,8 @@ private:
 	virtual void OnSend(int sendSize) {};
 	virtual void OnDisconnect() {};
 	
-	virtual void OnAssemblePacket(Packet* packet) { }
+public:
+	virtual void OnAssemblePacket(std::shared_ptr<Packet> packet) { }
 public:
 	SOCKET GetSocket() { return _socket; }
 	Buffer* GetRecvBuffer() { return &_recvBuffer; }


### PR DESCRIPTION
- 기존 MainThread, IocpThread 만 존재하는 구조에서 Logic를 처리하는 LogicThread를 분리했다.

- LogicThread는 Event를 통해 100ms 마다 실행되지만 그 전에 Job이 추가될 경우 바로 다시 Job을 탐색한다.